### PR TITLE
Fix mount pod secret not auto delete

### DIFF
--- a/pkg/juicefs/mount/pod_mount.go
+++ b/pkg/juicefs/mount/pod_mount.go
@@ -360,7 +360,7 @@ func (p *PodMount) createOrAddRef(ctx context.Context, podName string, jfsSettin
 						}
 					}
 				}
-
+				builder.SetPodAsOwner(&secret, *newPod)
 				if err := p.createOrUpdateSecret(ctx, &secret); err != nil {
 					return err
 				}


### PR DESCRIPTION
At present, there may be a large number of useless secrets.